### PR TITLE
Empty login object

### DIFF
--- a/src/bb.js
+++ b/src/bb.js
@@ -59,7 +59,7 @@ export default class BB {
     LoginCookie.setGlobal(response.headers.get('set-cookie'));
 
     const text = await response.text();
-    const { login } = JSON.parse(text);
+    const { login } = JSON.parse(text) || {};
 
     this.checking = new BBChecking();
     this.savings = new BBSavings();


### PR DESCRIPTION
Add {} to login when JSON.parser(text) throws exception